### PR TITLE
trim z scores before hmm peaks

### DIFF
--- a/rendseq/make_peaks.py
+++ b/rendseq/make_peaks.py
@@ -80,14 +80,18 @@ def hmm_peaks(z_scores, i_to_p=1 / 1000, p_to_p=1 / 1.5, peak_center=10, spread=
             column being a peak assignment.
     """
     print("Finding Peaks")
+    max_z = peak_center + spread
+    # cap the z scores at peak_center + spread to eliminate very large zscores.
+    trim_zscores = z_scores[:, :]
+    trim_zscores[:, 1] = np.where(z_scores[:, 1] > max_z, max_z, z_scores[:, 1])
     trans_m = np.asarray(
         [[(1 - i_to_p), (i_to_p)], [p_to_p, (1 - p_to_p)]]
     )  # transition probability
     peaks = np.zeros([len(z_scores), 2])
-    peaks[:, 0] = z_scores[:, 0]
+    peaks[:, 0] = trim_zscores[:, 0]
     states = [1, 100]  # how internal and peak are represented in the wig file
     trans_1, trans_2 = _populate_trans_mat(
-        z_scores, peak_center, spread, trans_m, states
+        trim_zscores, peak_center, spread, trans_m, states
     )
     # Now we trace backwards and find the most likely path:
     max_inds = np.zeros([len(peaks)]).astype(int)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to rendseq! If you haven't yet please check out our guidelines for contributing! (https://github.com/miraep8/rendseq/blob/main/CONTRIBUTING.md)

Feel free to add or remove sections below as needed.  This is intended to be a guideline for your PR.
-->

#### Explain your changes:
Basically just trim the z scores to be close to the center of the peak emission distribution.  This is just to handle the case where the z score is too high and thus the emission probabilities for both states end up being 0, and it ends up being labeled as an internal state.

#### Does this close any issues?

Closes #12 

See https://github.com/blog/1506-closing-issues-via-pull-requests for other keywords which work here.
-->

#### Any comments?  Anything in particular you need feedback on?

Also just wanted to check out that the PR template works.  Seems like it does :) 

This has made me realize need to write some more tests for hmm.  Will probably do this is a more systematic way in a future PR.  For the time being will make note of it in an issue (#28)

#### PR checklist

- [ ] I have written tests for my changes where needed and made sure they pass locally.
