### PR TITLE
Throw error if HMM peaks can not be computed.

### DIFF
--- a/rendseq/make_peaks.py
+++ b/rendseq/make_peaks.py
@@ -30,7 +30,7 @@ def _populate_trans_mat(z_scores, peak_center, spread, trans_m, states):
     Raises
     ------
         -ValueError if the HMM parameters are unable to find any likely paths.
-            This is at risk of happening if the emission probabilities are for
+            This is at risk of happening if the emission probabilities for
             either the peak state or the internal state look very different from
             the true distribution, or the parameters selected only allow a very
             unlikely path - for example if p_to_p = 1 and you try to force the

--- a/tests/test_make_peaks.py
+++ b/tests/test_make_peaks.py
@@ -198,7 +198,7 @@ class TestHmmPeaks:
         out, err = capfd.readouterr()
         assert out == "Finding Peaks\nCalculating Transition Matrix\nFound 1 Peaks\n"
 
-    def test_hmm_peaks_bad_paramters(self, z_scores):
+    def test_hmm_peaks_bad_parameters(self, z_scores):
         """A regular set of z scores with a peak"""
         z_scores[500, 1] = 12
         with pytest.raises(ValueError):
@@ -218,7 +218,6 @@ class TestHmmPeaks:
         all_peaks = array(
             [[loc, z] for loc, z in zip(range(1, NUM_PNTS), [100] * NUM_PNTS)]
         )
-        print(hmm_peaks(z_scores, peak_center=10, spread=0.1))
 
         assert_array_equal(hmm_peaks(z_scores, peak_center=10, spread=0.1), all_peaks)
 

--- a/tests/test_make_peaks.py
+++ b/tests/test_make_peaks.py
@@ -186,19 +186,6 @@ class TestHmmPeaks:
         out, err = capfd.readouterr()
         assert out == "Finding Peaks\nCalculating Transition Matrix\nFound 1 Peaks\n"
 
-    def test_hmm_peaks_extremePeak_inCenter(self, capfd, z_scores):
-        """A regular set of z scores with an extreme peak"""
-        z_scores[500, 1] = 10e4
-        peaks_almost_1 = array([[loc, z] for loc, z in zip(range(1, 1000), [1] * 1000)])
-        peaks_almost_1[500, 1] = 100
-
-        with pytest.warns(RuntimeWarning):
-            assert_array_equal(hmm_peaks(z_scores, peak_center=10e4), peaks_almost_1)
-
-        # Test print output
-        out, err = capfd.readouterr()
-        assert out == "Finding Peaks\nCalculating Transition Matrix\nFound 1 Peaks\n"
-
     def test_hmm_peaks_extremePeak_notinCenter(self, capfd, z_scores):
         """A regular set of z scores with an extreme peak"""
         z_scores[500, 1] = 10e4
@@ -210,6 +197,30 @@ class TestHmmPeaks:
         # Test print output
         out, err = capfd.readouterr()
         assert out == "Finding Peaks\nCalculating Transition Matrix\nFound 1 Peaks\n"
+
+    def test_hmm_peaks_bad_paramters(self, z_scores):
+        """A regular set of z scores with a peak"""
+        z_scores[500, 1] = 12
+        with pytest.raises(ValueError):
+            hmm_peaks(z_scores, i_to_p=0.5, p_to_p=0.99, peak_center=100, spread=0.5)
+
+    def test_hmm_peaks_p_to_p_is_one(self, z_scores):
+        """A regular set of z scores with a peak"""
+        NUM_PNTS = 1000
+        z_scores = array(
+            [
+                [loc, z]
+                for loc, z in zip(
+                    range(1, NUM_PNTS), normal(10, 0.1, size=(1, NUM_PNTS - 1))[0]
+                )
+            ]
+        )
+        all_peaks = array(
+            [[loc, z] for loc, z in zip(range(1, NUM_PNTS), [100] * NUM_PNTS)]
+        )
+        print(hmm_peaks(z_scores, peak_center=10, spread=0.1))
+
+        assert_array_equal(hmm_peaks(z_scores, peak_center=10, spread=0.1), all_peaks)
 
     # TODO: Tests for all of the hmm_peaks parameters
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to rendseq! If you haven't yet please check out our guidelines for contributing! (https://github.com/miraep8/rendseq/blob/main/CONTRIBUTING.md)

Feel free to add or remove sections below as needed.  This is intended to be a guideline for your PR.
-->

#### Explain your changes:
I changed `_populate_trans_mat` so that it will throw an exception if the parameters provided lead to sufficiently low probability states such that all of the transition states are -Inf.   Added some tests to verify that this state is caught.  Check that p_to_p = 1 leads to all positions being called peaks for reasonable data.

#### Does this close any issues?
<!--
Please link the issue/PR you close or reference.  For example:
 Closes #37

See https://github.com/blog/1506-closing-issues-via-pull-requests for other keywords which work here.
-->

Closes #13 

#### Any comments?  Anything in particular you need feedback on?


#### PR checklist

- [x] I have written tests for my changes where needed and made sure they pass locally.
