### PR TITLE
Add a parameter to name kink image in thresh_peaks

### DIFF
--- a/rendseq/make_peaks.py
+++ b/rendseq/make_peaks.py
@@ -190,7 +190,7 @@ def _calc_thresh(z_scores, method, kink_img="./kink.png"):
     return thresh
 
 
-def thresh_peaks(z_scores, thresh=None, method="kink"):
+def thresh_peaks(z_scores, thresh=None, method="kink", kink_image="./kink.png"):
     """Find peaks by calling z-scores above a threshold as a peak.
 
     Parameters
@@ -202,7 +202,7 @@ def thresh_peaks(z_scores, thresh=None, method="kink"):
             if none is provided.  Default method is "kink"
     """
     if thresh is None:
-        thresh = _calc_thresh(z_scores, method)
+        thresh = _calc_thresh(z_scores, method, kink_image)
     peaks = np.zeros([len(z_scores), 2])
     peaks[:, 0] = z_scores[:, 0]
     peaks[:, 1] = (z_scores[:, 1] > thresh).astype(int)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to rendseq! If you haven't yet please check out our guidelines for contributing! (https://github.com/miraep8/rendseq/blob/main/CONTRIBUTING.md)

Feel free to add or remove sections below as needed.  This is intended to be a guideline for your PR.
-->

#### Explain your changes:

I am using this pipeline on real data and am calculating Z scores for multiple files, like this:

![image](https://user-images.githubusercontent.com/22749289/174445537-994d310a-4ccb-4821-91a8-42a6ebd6a7a6.png)

There's two issues here: (1) it combines the kink plots from all the files, so I just added `plt.figure()` to my wrapper, and (2) it saves all the images as kink.png, so it overwrites previous ones.

No problem, let's just add a parameter to thresh_peaks to let us name the image files so I can save them each with the name of their associated wig file.

#### Does this close any issues?
<!--
Please link the issue/PR you close or reference.  For example:
 Closes #37

See https://github.com/blog/1506-closing-issues-via-pull-requests for other keywords which work here.
-->

#### Any comments?  Anything in particular you need feedback on?


#### PR checklist

- [ ] I have written tests for my changes where needed and made sure they pass locally.
