### PR TITLE
Maitenence - bumping isort hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: ^docs/
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort


### PR DESCRIPTION
#### Explain your changes:

The current `isort` hook raises an error with Poetry in the pre-commit hooks. (see screenshot below)  I think that updating the version of `isort` used should fix this issue.

<img width="799" alt="image" src="https://user-images.githubusercontent.com/10511777/221639125-0d2518f5-0ab6-4345-a361-5af4e4df4af0.png">

