### PR TITLE
Increase speed of z score calcuations

### DIFF
--- a/rendseq/make_peaks.py
+++ b/rendseq/make_peaks.py
@@ -203,9 +203,9 @@ def thresh_peaks(z_scores, thresh=None, method="kink"):
     """
     if thresh is None:
         thresh = _calc_thresh(z_scores, method)
-    peaks = np.zeros([len(z_scores), 2])
+    peaks = 100 * np.ones([len(z_scores), 2])
     peaks[:, 0] = z_scores[:, 0]
-    peaks[:, 1] = (z_scores[:, 1] > thresh).astype(int)
+    peaks = np.delete(peaks, z_scores[:, 1] < thresh, 0)
     return peaks
 
 


### PR DESCRIPTION
This code significantly increases the speed of z score calculation. 
- The way we remove potential outliers has changed - now we remove the top ~20% of values before calculating mean and sd (rather than relying on a sd based approach for outlier detection.  This will also have the effect of reducing the calculated mean a bit (which will slightly inflate the z score for all values) but should reduce the sd enough to help us catch real peaks). 
- I now automatically add gaussian padding to all missing values from the original array.  This means we can now more easily take advantage of the numpy under the hood optimizations. 

Still missing - need to add some tests for the changes that I have made. 